### PR TITLE
Do not redirect when x-forwarded-proto header is missing

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -52,7 +52,7 @@ describe("responds accordingly", () => {
     // @ts-ignore
     middleware(dummyReq, dummyRes, {});
 
-    expect(fakeRedirect).toBeCalled();
+    expect(fakeRedirect).not.toBeCalled();
   });
 
   it("runs on insecure urls", () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -53,7 +53,8 @@ describe("responds accordingly", () => {
     middleware(dummyReq, dummyRes, {});
 
     expect(fakeRedirect).not.toBeCalled();
-  });
+    expect(fakeNext).toBeCalled();
+ });
 
   it("runs on insecure urls", () => {
     // @ts-ignore

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,11 @@ const sslRedirect = (
 
   return (req: Request, res: Response, next: NextFunction) => {
     if (isCurrentEnv) {
-      req.headers["x-forwarded-proto"] !== "https"
+      // Only redirect if the x-forwarded-proto is present and not equal to https.
+      // This prevents unwanted redirects in the case where a server makes intra-server
+      // requests that don't reach the heroku router and thus don't get x-forwarded-proto
+      // added.
+      req.headers["x-forwarded-proto"] && req.headers["x-forwarded-proto"] !== "https"
         ? res.redirect(status, "https://" + req.hostname + req.originalUrl)
         : next();
     } else next();


### PR DESCRIPTION
Only redirect if the x-forwarded-proto **is present** and not equal to https.

The test was actually written this way, but the body of the test didn't match the description:
```
it("only redirects if it has header x-forwarded-proto", () => {
```

This prevents an SSR app on Heroku from 302-ing API requests made on the server which circumvent (apparently) the heroku router. This won't have any impact on inbound requests.